### PR TITLE
fix church page routing bug

### DIFF
--- a/saint-central/app/(tabs)/churchDetails.tsx
+++ b/saint-central/app/(tabs)/churchDetails.tsx
@@ -349,7 +349,7 @@ export default function ChurchDetailsScreen(): JSX.Element {
       // Navigate to church page
       navigation.reset({
         index: 0,
-        routes: [{ name: "church" as never }],
+        routes: [{ name: "home" as never }],
       });
     } catch (error) {
       console.error("Error joining church:", error);

--- a/saint-central/app/(tabs)/churchSearch.tsx
+++ b/saint-central/app/(tabs)/churchSearch.tsx
@@ -173,7 +173,7 @@ export default function ChurchSearchScreen(): JSX.Element {
       // Navigate to church page
       navigation.reset({
         index: 0,
-        routes: [{ name: "church" }],
+        routes: [{ name: "home" }],
       });
     } catch (error) {
       console.error("Error joining church:", error);

--- a/saint-central/app/(tabs)/home.tsx
+++ b/saint-central/app/(tabs)/home.tsx
@@ -1,65 +1,28 @@
-import React, { useState, useEffect, useRef } from "react";
-import {
-  StyleSheet,
-  Text,
-  View,
-  SafeAreaView,
-  Animated,
-  StatusBar,
-  TouchableOpacity,
-  Platform,
-} from "react-native";
+import { useState, useEffect, useCallback } from "react";
+import { StyleSheet, View } from "react-native";
 import { supabase } from "../../supabaseClient";
-import { Ionicons, FontAwesome5, MaterialCommunityIcons } from "@expo/vector-icons";
 import LottieView from "lottie-react-native";
-import { LinearGradient } from "expo-linear-gradient";
-import theme from "@/theme";
-import DecoratedHeader from "@/components/ui/DecoratedHeader";
-import Card from "@/components/ui/Card";
-import Button from "@/components/ui/Button";
-import { useRouter } from "expo-router";
 import ChurchPageLayout from "@/components/church/ChurchPageLayout";
+import ChurchPageFallback from "@/components/church/ChuchPageFallback";
+import { ChurchContext, ChurchContextData } from "@/contexts/church";
+import { ChurchMember } from "@/types/church";
 
-// Add CardDecoration component
-const CardDecoration = () => (
-  <View style={{ position: "absolute", top: 10, right: 10, opacity: 0.1 }}>
-    <FontAwesome5 name="cross" size={80} color="#FFFFFF" />
-  </View>
-);
-
-export default function ChurchMembershipScreen(): JSX.Element {
-  const router = useRouter();
+export default function ChurchMembershipScreen() {
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<Error | null>(null);
-  const [isMember, setIsMember] = useState<boolean | null>(null);
-  const [shouldNavigate, setShouldNavigate] = useState<boolean>(false);
 
-  const fadeAnim = useRef(new Animated.Value(0)).current;
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const buttonAnimValues = [0, 1, 2].map(() => useRef(new Animated.Value(0)).current);
+  const [churchData, setChurchData] = useState<ChurchContextData>({});
+  const [userData, setUserData] = useState<{ username: string; profileImage: string }>({
+    username: "Friend",
+    profileImage: "",
+  });
+  const updateChurchData = useCallback((data: ChurchContextData) => {
+    setChurchData(data);
+  }, []);
+  const resetChurchData = useCallback(() => {
+    setChurchData({});
+  }, []);
 
-  // Handle animations
-  useEffect(() => {
-    // Animate content fade in
-    Animated.timing(fadeAnim, {
-      toValue: 1,
-      duration: 800,
-      useNativeDriver: true,
-    }).start();
-
-    // Animate buttons entrance with staggered delay
-    buttonAnimValues.forEach((anim, index) => {
-      Animated.spring(anim, {
-        toValue: 1,
-        tension: 50,
-        friction: 7,
-        delay: 400 + index * 100,
-        useNativeDriver: true,
-      }).start();
-    });
-  }, [buttonAnimValues, fadeAnim]);
-
-  // Fetch user data and check church membership
   useEffect(() => {
     async function checkChurchMembership(): Promise<void> {
       setLoading(true);
@@ -73,46 +36,46 @@ export default function ChurchMembershipScreen(): JSX.Element {
         const user = sessionData?.session?.user;
         if (!user || !user.id) {
           console.log("No valid user in session");
-          setIsMember(false);
           return;
         }
 
+        // get user profile data
+        const { data: userData, error: profileError } = await supabase
+          .from("users")
+          .select("first_name, profile_image")
+          .eq("id", user.id)
+          .single();
+        if (profileError) {
+          console.error("Error fetching user profile:", profileError);
+        } else if (userData) {
+          setUserData((current) => ({
+            username: userData.first_name || current.username,
+            profileImage: userData.profile_image || current.profileImage,
+          }));
+        }
+
+        // get church member data
         const userId = user.id;
-        console.log("Checking membership for user_id:", userId);
+        console.log("Getting member data for user_id:", userId);
         const { data: memberData, error: memberError } = await supabase
           .from("church_members")
-          .select("id, church_id, role")
-          .eq("user_id", userId);
-        if (memberError) {
-          throw memberError;
-        }
-
-        const membershipStatus = memberData && memberData.length > 0;
-        setIsMember(membershipStatus);
-        if (membershipStatus) {
-          console.log("Setting shouldNavigate to true");
-          setShouldNavigate(true);
+          .select("*")
+          .eq("user_id", user.id)
+          .single();
+        console.log(memberData, memberError);
+        if (memberData && !memberError) {
+          console.log((memberData as ChurchMember).user_id, "is member");
+          updateChurchData({ member: memberData });
         }
       } catch (error) {
-        console.error("Error checking church membership:", error);
+        console.error("Error while loading church page:", error);
         setError(error instanceof Error ? error : new Error("Unknown error"));
-        setIsMember(false);
-      } finally {
-        setLoading(false);
       }
     }
-    checkChurchMembership();
-  }, []);
-
-  // Button press animation
-  const pressButton = (index: number, pressed: boolean) => {
-    Animated.spring(buttonAnimValues[index], {
-      toValue: pressed ? 0.97 : 1,
-      friction: 5,
-      tension: 40,
-      useNativeDriver: true,
-    }).start();
-  };
+    checkChurchMembership().finally(() => {
+      setLoading(false);
+    });
+  }, [updateChurchData]);
 
   // Loading State
   if (loading) {
@@ -133,172 +96,22 @@ export default function ChurchMembershipScreen(): JSX.Element {
     );
   }
 
-  if (shouldNavigate && !loading) {
-    return <ChurchPageLayout />;
+  // if we have a church member, render the layout
+  // else render the fallback
+  if (!loading && churchData.member) {
+    return (
+      <ChurchContext.Provider
+        value={{ data: churchData, update: updateChurchData, reset: resetChurchData }}
+      >
+        <ChurchPageLayout userData={userData} />
+      </ChurchContext.Provider>
+    );
   }
 
-  // Not a church member UI
-  return (
-    <SafeAreaView style={styles.container}>
-      <StatusBar barStyle="dark-content" backgroundColor="transparent" translucent />
-      <DecoratedHeader
-        label="Find Your Community"
-        styles={{ marginTop: theme.spacingTopBar, marginBottom: 30, marginLeft: 20 }}
-      />
-      <Animated.View
-        style={[
-          styles.mainContent,
-          {
-            opacity: fadeAnim,
-            transform: [
-              {
-                translateY: fadeAnim.interpolate({
-                  inputRange: [0, 1],
-                  outputRange: [20, 0],
-                }),
-              },
-            ],
-          },
-        ]}
-      >
-        {error ? (
-          <View style={styles.errorContainer}>
-            <Ionicons name="alert-circle-outline" size={20} color={theme.textErrorColor} />
-            <Text style={styles.errorText}>Something went wrong. Please try again.</Text>
-          </View>
-        ) : (
-          <>
-            <View style={styles.infoCard}>
-              <LinearGradient
-                colors={[theme.cardInfoGradientStart, theme.cardInfoGradientEnd]}
-                start={{ x: 0, y: 0 }}
-                end={{ x: 1, y: 1 }}
-                style={styles.infoCardGradient}
-              >
-                <CardDecoration />
-                <TouchableOpacity
-                  activeOpacity={0.85}
-                  onPressIn={() => pressButton(2, true)}
-                  onPressOut={() => pressButton(2, false)}
-                  onPress={() => router.navigate("/registerChurch")}
-                  style={styles.registerButtonContainer}
-                >
-                  <Animated.View
-                    style={[
-                      {
-                        transform: [{ scale: buttonAnimValues[2] }],
-                      },
-                    ]}
-                  >
-                    <LinearGradient
-                      colors={["#4CAF50", "#2E7D32"]}
-                      start={{ x: 0, y: 0 }}
-                      end={{ x: 1, y: 0 }}
-                      style={styles.registerButton}
-                    >
-                      <FontAwesome5 name="plus-circle" size={12} color="#FFFFFF" />
-                      <Text style={styles.registerButtonText}>Register Church</Text>
-                    </LinearGradient>
-                  </Animated.View>
-                </TouchableOpacity>
-                <View style={styles.infoIconContainer}>
-                  <LinearGradient colors={["#3A86FF", "#4361EE"]} style={styles.infoIcon}>
-                    <FontAwesome5 name="church" size={26} color="#FFFFFF" />
-                  </LinearGradient>
-                </View>
-                <Text style={styles.infoTitle}>Join a Church Community</Text>
-                <Text style={styles.infoDescription}>
-                  Connect with a local church to grow in faith, access resources, and join
-                  fellowship activities.
-                </Text>
-              </LinearGradient>
-            </View>
-
-            <View style={styles.buttonsContainer}>
-              <Animated.View
-                style={[
-                  styles.buttonWrapper,
-                  {
-                    transform: [
-                      { scale: buttonAnimValues[0] },
-                      {
-                        translateY: buttonAnimValues[0].interpolate({
-                          inputRange: [0, 1],
-                          outputRange: [20, 0],
-                        }),
-                      },
-                    ],
-                    opacity: buttonAnimValues[0],
-                  },
-                ]}
-              >
-                <Button
-                  onPressIn={() => pressButton(0, true)}
-                  onPressOut={() => pressButton(0, false)}
-                  onPress={() => router.navigate("/churchSearch")}
-                >
-                  <MaterialCommunityIcons
-                    name="magnify"
-                    size={20}
-                    color="#FFFFFF"
-                    style={styles.buttonIcon}
-                  />
-                  <Text style={styles.primaryButtonText}>Search for a Church</Text>
-                </Button>
-              </Animated.View>
-
-              <Animated.View
-                style={[
-                  styles.buttonWrapper,
-                  {
-                    transform: [
-                      { scale: buttonAnimValues[1] },
-                      {
-                        translateY: buttonAnimValues[1].interpolate({
-                          inputRange: [0, 1],
-                          outputRange: [20, 0],
-                        }),
-                      },
-                    ],
-                    opacity: buttonAnimValues[1],
-                  },
-                ]}
-              >
-                <TouchableOpacity
-                  activeOpacity={0.85}
-                  onPressIn={() => pressButton(1, true)}
-                  onPressOut={() => pressButton(1, false)}
-                  onPress={() => alert("In progress")}
-                >
-                  <LinearGradient
-                    colors={["#FF9800", "#F57C00"]}
-                    start={{ x: 0, y: 0 }}
-                    end={{ x: 1, y: 0 }}
-                    style={styles.primaryButton}
-                  >
-                    <MaterialCommunityIcons
-                      name="account-group"
-                      size={20}
-                      color="#FFFFFF"
-                      style={styles.buttonIcon}
-                    />
-                    <Text style={styles.primaryButtonText}>Search for a Community</Text>
-                  </LinearGradient>
-                </TouchableOpacity>
-              </Animated.View>
-            </View>
-          </>
-        )}
-      </Animated.View>
-    </SafeAreaView>
-  );
+  return <ChurchPageFallback error={error} />;
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: "#fff",
-  },
   loadingContainer: {
     flex: 1,
     justifyContent: "center",
@@ -314,106 +127,5 @@ const styles = StyleSheet.create({
   lottieAnimation: {
     width: 120,
     height: 120,
-  },
-  mainContent: {
-    flex: 1,
-    paddingHorizontal: 20,
-  },
-  infoCard: {
-    marginBottom: 30,
-    borderRadius: 20,
-    overflow: "hidden",
-  },
-  infoCardGradient: {
-    borderRadius: 20,
-    padding: 20,
-    borderWidth: 1,
-    borderColor: theme.cardInfoBorderColor,
-  },
-  registerButtonContainer: {
-    position: "absolute",
-    top: 12,
-    right: 12,
-    zIndex: 10,
-  },
-  registerButton: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "center",
-    paddingHorizontal: 10,
-    paddingVertical: 6,
-    borderRadius: 12,
-  },
-  registerButtonText: {
-    fontSize: 11,
-    fontWeight: theme.fontMedium,
-    color: "#FFFFFF",
-    marginLeft: 4,
-  },
-  infoIconContainer: {
-    alignItems: "center",
-    marginBottom: 16,
-  },
-  infoIcon: {
-    width: 60,
-    height: 60,
-    borderRadius: 30,
-    justifyContent: "center",
-    alignItems: "center",
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 3 },
-    shadowOpacity: 0.1,
-    shadowRadius: 4.5,
-    elevation: 3,
-  },
-  infoTitle: {
-    fontSize: 18,
-    fontWeight: theme.fontBold,
-    color: theme.textForeground,
-    textAlign: "center",
-    marginBottom: 12,
-  },
-  infoDescription: {
-    fontSize: 14,
-    lineHeight: 22,
-    color: theme.textForegroundMuted,
-    textAlign: "center",
-  },
-  buttonsContainer: {
-    marginBottom: 40,
-  },
-  buttonWrapper: {
-    marginBottom: 16,
-  },
-  buttonIcon: {
-    marginRight: 8,
-  },
-  primaryButton: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "center",
-    borderRadius: 15,
-    paddingVertical: 14,
-    paddingHorizontal: 20,
-  },
-  primaryButtonText: {
-    fontSize: 16,
-    fontWeight: theme.fontBold,
-    color: theme.buttonText,
-  },
-  errorContainer: {
-    flexDirection: "row",
-    alignItems: "center",
-    backgroundColor: theme.cardErrorBackground,
-    padding: 16,
-    borderRadius: 16,
-    marginBottom: 20,
-  },
-  errorText: {
-    fontSize: 14,
-    color: theme.textErrorColor,
-    marginLeft: 12,
-    fontWeight: theme.fontMedium,
-    flex: 1,
   },
 });

--- a/saint-central/components/church/ChuchPageFallback.tsx
+++ b/saint-central/components/church/ChuchPageFallback.tsx
@@ -1,0 +1,329 @@
+import React, { useEffect, useRef } from "react";
+import {
+  StyleSheet,
+  Text,
+  View,
+  SafeAreaView,
+  Animated,
+  StatusBar,
+  TouchableOpacity,
+} from "react-native";
+import { Ionicons, FontAwesome5, MaterialCommunityIcons } from "@expo/vector-icons";
+import { LinearGradient } from "expo-linear-gradient";
+import theme from "@/theme";
+import DecoratedHeader from "@/components/ui/DecoratedHeader";
+import Button from "@/components/ui/Button";
+import { useRouter } from "expo-router";
+
+type Props = {
+  error?: Error | null;
+};
+
+const CardDecoration = () => (
+  <View style={{ position: "absolute", top: 10, right: 10, opacity: 0.1 }}>
+    <FontAwesome5 name="cross" size={80} color="#FFFFFF" />
+  </View>
+);
+
+export default function ChurchPageFallback({ error }: Props) {
+  const router = useRouter();
+
+  const fadeAnim = useRef(new Animated.Value(0)).current;
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const buttonAnimValues = [0, 1, 2].map(() => useRef(new Animated.Value(0)).current);
+
+  // Handle animations
+  useEffect(() => {
+    // Animate content fade in
+    Animated.timing(fadeAnim, {
+      toValue: 1,
+      duration: 800,
+      useNativeDriver: true,
+    }).start();
+
+    // Animate buttons entrance with staggered delay
+    buttonAnimValues.forEach((anim, index) => {
+      Animated.spring(anim, {
+        toValue: 1,
+        tension: 50,
+        friction: 7,
+        delay: 400 + index * 100,
+        useNativeDriver: true,
+      }).start();
+    });
+  }, [buttonAnimValues, fadeAnim]);
+
+  // Button press animation
+  const pressButton = (index: number, pressed: boolean) => {
+    Animated.spring(buttonAnimValues[index], {
+      toValue: pressed ? 0.97 : 1,
+      friction: 5,
+      tension: 40,
+      useNativeDriver: true,
+    }).start();
+  };
+
+  // Not a church member UI
+  return (
+    <SafeAreaView style={styles.container}>
+      <StatusBar barStyle="dark-content" backgroundColor="transparent" translucent />
+      <DecoratedHeader
+        label="Find Your Community"
+        styles={{ marginTop: theme.spacingTopBar, marginBottom: 30, marginLeft: 20 }}
+      />
+      <Animated.View
+        style={[
+          styles.mainContent,
+          {
+            opacity: fadeAnim,
+            transform: [
+              {
+                translateY: fadeAnim.interpolate({
+                  inputRange: [0, 1],
+                  outputRange: [20, 0],
+                }),
+              },
+            ],
+          },
+        ]}
+      >
+        {error ? (
+          <View style={styles.errorContainer}>
+            <Ionicons name="alert-circle-outline" size={20} color={theme.textErrorColor} />
+            <Text style={styles.errorText}>Something went wrong. Please try again.</Text>
+          </View>
+        ) : (
+          <>
+            <View style={styles.infoCard}>
+              <LinearGradient
+                colors={[theme.cardInfoGradientStart, theme.cardInfoGradientEnd]}
+                start={{ x: 0, y: 0 }}
+                end={{ x: 1, y: 1 }}
+                style={styles.infoCardGradient}
+              >
+                <CardDecoration />
+                <TouchableOpacity
+                  activeOpacity={0.85}
+                  onPressIn={() => pressButton(2, true)}
+                  onPressOut={() => pressButton(2, false)}
+                  onPress={() => router.navigate("/registerChurch")}
+                  style={styles.registerButtonContainer}
+                >
+                  <Animated.View
+                    style={[
+                      {
+                        transform: [{ scale: buttonAnimValues[2] }],
+                      },
+                    ]}
+                  >
+                    <LinearGradient
+                      colors={["#4CAF50", "#2E7D32"]}
+                      start={{ x: 0, y: 0 }}
+                      end={{ x: 1, y: 0 }}
+                      style={styles.registerButton}
+                    >
+                      <FontAwesome5 name="plus-circle" size={12} color="#FFFFFF" />
+                      <Text style={styles.registerButtonText}>Register Church</Text>
+                    </LinearGradient>
+                  </Animated.View>
+                </TouchableOpacity>
+                <View style={styles.infoIconContainer}>
+                  <LinearGradient colors={["#3A86FF", "#4361EE"]} style={styles.infoIcon}>
+                    <FontAwesome5 name="church" size={26} color="#FFFFFF" />
+                  </LinearGradient>
+                </View>
+                <Text style={styles.infoTitle}>Join a Church Community</Text>
+                <Text style={styles.infoDescription}>
+                  Connect with a local church to grow in faith, access resources, and join
+                  fellowship activities.
+                </Text>
+              </LinearGradient>
+            </View>
+
+            <View style={styles.buttonsContainer}>
+              <Animated.View
+                style={[
+                  styles.buttonWrapper,
+                  {
+                    transform: [
+                      { scale: buttonAnimValues[0] },
+                      {
+                        translateY: buttonAnimValues[0].interpolate({
+                          inputRange: [0, 1],
+                          outputRange: [20, 0],
+                        }),
+                      },
+                    ],
+                    opacity: buttonAnimValues[0],
+                  },
+                ]}
+              >
+                <Button
+                  onPressIn={() => pressButton(0, true)}
+                  onPressOut={() => pressButton(0, false)}
+                  onPress={() => router.navigate("/churchSearch")}
+                >
+                  <MaterialCommunityIcons
+                    name="magnify"
+                    size={20}
+                    color="#FFFFFF"
+                    style={styles.buttonIcon}
+                  />
+                  <Text style={styles.primaryButtonText}>Search for a Church</Text>
+                </Button>
+              </Animated.View>
+
+              <Animated.View
+                style={[
+                  styles.buttonWrapper,
+                  {
+                    transform: [
+                      { scale: buttonAnimValues[1] },
+                      {
+                        translateY: buttonAnimValues[1].interpolate({
+                          inputRange: [0, 1],
+                          outputRange: [20, 0],
+                        }),
+                      },
+                    ],
+                    opacity: buttonAnimValues[1],
+                  },
+                ]}
+              >
+                <TouchableOpacity
+                  activeOpacity={0.85}
+                  onPressIn={() => pressButton(1, true)}
+                  onPressOut={() => pressButton(1, false)}
+                  onPress={() => alert("In progress")}
+                >
+                  <LinearGradient
+                    colors={["#FF9800", "#F57C00"]}
+                    start={{ x: 0, y: 0 }}
+                    end={{ x: 1, y: 0 }}
+                    style={styles.primaryButton}
+                  >
+                    <MaterialCommunityIcons
+                      name="account-group"
+                      size={20}
+                      color="#FFFFFF"
+                      style={styles.buttonIcon}
+                    />
+                    <Text style={styles.primaryButtonText}>Search for a Community</Text>
+                  </LinearGradient>
+                </TouchableOpacity>
+              </Animated.View>
+            </View>
+          </>
+        )}
+      </Animated.View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#fff",
+  },
+  mainContent: {
+    flex: 1,
+    paddingHorizontal: 20,
+  },
+  infoIconContainer: {
+    alignItems: "center",
+    marginBottom: 16,
+  },
+  infoIcon: {
+    width: 60,
+    height: 60,
+    borderRadius: 30,
+    justifyContent: "center",
+    alignItems: "center",
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 3 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4.5,
+    elevation: 3,
+  },
+  infoTitle: {
+    fontSize: 18,
+    fontWeight: theme.fontBold,
+    color: theme.textForeground,
+    textAlign: "center",
+    marginBottom: 12,
+  },
+  infoDescription: {
+    fontSize: 14,
+    lineHeight: 22,
+    color: theme.textForegroundMuted,
+    textAlign: "center",
+  },
+  buttonsContainer: {
+    marginBottom: 40,
+  },
+  errorContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: theme.cardErrorBackground,
+    padding: 16,
+    borderRadius: 16,
+    marginBottom: 20,
+  },
+  errorText: {
+    fontSize: 14,
+    color: theme.textErrorColor,
+    marginLeft: 12,
+    fontWeight: theme.fontMedium,
+    flex: 1,
+  },
+  infoCard: {
+    marginBottom: 30,
+    borderRadius: 20,
+    overflow: "hidden",
+  },
+  infoCardGradient: {
+    borderRadius: 20,
+    padding: 20,
+    borderWidth: 1,
+    borderColor: theme.cardInfoBorderColor,
+  },
+  registerButtonContainer: {
+    position: "absolute",
+    top: 12,
+    right: 12,
+    zIndex: 10,
+  },
+  registerButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 12,
+  },
+  registerButtonText: {
+    fontSize: 11,
+    fontWeight: theme.fontMedium,
+    color: "#FFFFFF",
+    marginLeft: 4,
+  },
+  buttonWrapper: {
+    marginBottom: 16,
+  },
+  buttonIcon: {
+    marginRight: 8,
+  },
+  primaryButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: 15,
+    paddingVertical: 14,
+    paddingHorizontal: 20,
+  },
+  primaryButtonText: {
+    fontSize: 16,
+    fontWeight: theme.fontBold,
+    color: theme.buttonText,
+  },
+});

--- a/saint-central/components/church/ChurchPageContent.tsx
+++ b/saint-central/components/church/ChurchPageContent.tsx
@@ -15,8 +15,8 @@ import ChurchProfileCard from "./ChurchProfileCard";
 import theme from "@/theme";
 import { useState } from "react";
 import { supabase } from "@/supabaseClient";
-import { useRouter } from "expo-router";
 import { LinearGradient } from "expo-linear-gradient";
+import { useChurchContext } from "@/contexts/church";
 
 type Props = {
   church: Church;
@@ -25,8 +25,8 @@ type Props = {
 };
 
 export default function ChurchPageContent({ church, member, userData }: Props) {
-  const router = useRouter();
   const [leavingChurch, setLeavingChurch] = useState<boolean>(false);
+  const { reset: resetChurchData } = useChurchContext();
 
   const handleLeaveChurch = async (): Promise<void> => {
     if (!member) return;
@@ -47,7 +47,7 @@ export default function ChurchPageContent({ church, member, userData }: Props) {
         .eq("id", member.id);
       if (deleteError) throw deleteError;
 
-      router.navigate("/home");
+      resetChurchData();
     } catch (error) {
       console.error("Error leaving church:", error);
       Alert.alert("Error", "Failed to leave the church. Please try again later.");

--- a/saint-central/contexts/church.tsx
+++ b/saint-central/contexts/church.tsx
@@ -1,0 +1,23 @@
+import { Church, ChurchMember } from "@/types/church";
+import { createContext, useContext } from "react";
+
+export type ChurchContextData = {
+  church?: Church;
+  member?: ChurchMember;
+};
+
+export type ChurchContextValue = {
+  data: ChurchContextData;
+  update: (data: ChurchContextData) => void;
+  reset: () => void;
+};
+
+export const ChurchContext = createContext<ChurchContextValue | null>(null);
+
+export function useChurchContext() {
+  const contextValue = useContext(ChurchContext);
+  if (contextValue === null) {
+    throw new Error("'useChurch' hook requires a 'ChurchProvider'");
+  }
+  return contextValue;
+}


### PR DESCRIPTION
## Problem
There was a bug happening because when the user would click to leave a church, the page would navigate to itself by calling `navigation.reset`. However, in `ChurchPageLayout.tsx`, we fetch the user's membership data inside of a `useEffect` that depends on `router.params`, which was getting changed when `navigation.reset` is called.
## Solution
* Fetch the church member data in `home.tsx` instead, storing the data in a Context.
* Conditionally render depending on whether the Context contains membership data or not.
* In `ChurchPageLayout.tsx`, instead of refreshing the page or resetting the router, reset the context to delete the member data.
## New component
There's a new component called `ChurchFallback.tsx` that renders the UI for when a user is not part of any church. (the search churches, search communities, and register church buttons).